### PR TITLE
Add link to public git repository

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,12 @@ license = "MIT"
 authors = [
   {name = "Giordano Alves", email = "giordano.alves9@gmail.com"}
 ]
+
+[project.urls]
+Homepage = "https://github.com/giordano-dev/VCSP"
+Repository = "https://github.com/giordano-dev/VCSP"
+Issues = "https://github.com/giordano-dev/VCSP/issues"
+
 classifiers = [
     "Programming Language :: Python :: 3",
     "Operating System :: OS Independent",


### PR DESCRIPTION
Add the link to point to the repository of the project so people looking at pypi can easily find it and contribute to this project. For explanation see https://packaging.python.org/en/latest/guides/writing-pyproject-toml/