### PR TITLE
add dependabot to send PRs when a GitHub Action is out of date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      all-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
I've noticed that the `actions/checkout` in your CI used version 4 while it is already on version 6.

The dependabot configuration in this PR will monitor this and send you a PR when one or more of the actions are out of date. For more explanation see https://docs.github.com/en/code-security/getting-started/dependabot-quickstart-guide