### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -96,7 +96,7 @@ stevedore==5.6.0
     # via bandit
 tomli==2.3.0
     # via pip-audit
-urllib3==2.6.2
+urllib3==2.6.3
     # via requests
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
A security vulnerability has been reported in the urllib3 2.6.2 library listed at https://www.cve.org/CVERecord?id=CVE-2026-21441. The urllib lib is installed in the requests lib package, which is currently at version 2.32.5 and was last updated on August 18, 2025, still using version 2.6.2. Please be aware of the use of this lib and update urllib to version 2.6.3 individually.